### PR TITLE
Downgrade matplotlib version to 3.7.0 in requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 hydra-core==1.3.2
 imageio==2.31.1
-matplotlib==3.7.1
+matplotlib==3.7.0
 numpy==1.25.0
 omegaconf==2.3.0
 pandas==2.0.2


### PR DESCRIPTION
Currently, there is "Axes3D has no attribute w_xasix" with matplotlib Axes 3D due to some recent updates. Other packages have had similar issue and is resolved by downgrading matplotlib to 3.7.0 and worked for me as well. This error is throw because visualization.py calls the w_xaxis attribute.
https://github.com/louwrentius/fio-plot/issues/141